### PR TITLE
FIX: Ensure compatibility with changed method signatures in neos/flow…

### DIFF
--- a/Classes/Infrastructure/Doctrine/DataTypes/JsonArrayType.php
+++ b/Classes/Infrastructure/Doctrine/DataTypes/JsonArrayType.php
@@ -14,7 +14,7 @@ final class JsonArrayType extends FlowJsonArrayType
      * @param array<mixed> $array
      * @return void
      */
-    protected function decodeObjectReferences(array &$array)
+    protected function decodeObjectReferences(array &$array): void
     {
         foreach ($array as &$value) {
             if (is_array($value) && isset($value['__value_object_value']) && isset($value['__value_object_type'])) {
@@ -30,7 +30,7 @@ final class JsonArrayType extends FlowJsonArrayType
      * @return void
      * @throws \RuntimeException
      */
-    protected function encodeObjectReferences(array &$array)
+    protected function encodeObjectReferences(array &$array): void
     {
         foreach ($array as &$value) {
             if ($value instanceof \JsonSerializable && DenormalizingObjectConverter::isDenormalizable(get_class($value))) {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "neos/neos": "^5.0 || ^7.0 || ^8.0 || dev-master"
+        "neos/neos": "^8.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",


### PR DESCRIPTION
JsonArrayType has changed in neos/flow 8.3, this adds the missing return-type signatures and removes compatibility with older versions